### PR TITLE
Inquisition Mask Slot Fix (and Eora too)

### DIFF
--- a/code/modules/clothing/rogueclothes/hats/hats.dm
+++ b/code/modules/clothing/rogueclothes/hats/hats.dm
@@ -134,6 +134,7 @@
 	desc = "A silver opera mask worn by the faithful of Eora, usually during their rituals."
 	icon_state = "eoramask"
 	mob_overlay_icon = 'icons/roguetown/clothing/onmob/64x64/head.dmi'
+	slot_flags = ITEM_SLOT_MASK|ITEM_SLOT_HEAD
 	worn_x_dimension = 64
 	worn_y_dimension = 64
 	dynamic_hair_suffix = ""
@@ -1702,7 +1703,7 @@
     body_parts_covered = FACE|HEAD|HAIR|EARS|NOSE
     flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH
     block2add = FOV_BEHIND
-    slot_flags = ITEM_SLOT_HEAD|ITEM_SLOT_HIP
+    slot_flags = ITEM_SLOT_HEAD|ITEM_SLOT_HIP|ITEM_SLOT_MASK
     sellprice = 25
 
 /obj/item/clothing/head/roguetown/helmet/overseer/vice


### PR DESCRIPTION
## About The Pull Request

Inquisitor Mask fixed for Mask Slot
Confessor Mask fixed for Mask Slot
Eoran Mask fixed for Mask slot

As clarification, these masks are purely aesthetic.

In short, made these three masks capable of actually being worn in the mask slot.. As intended.

## Why It's Good For The Game

Drip or drown. And brother, I'm dripping.
