### PR TITLE
Blacksmithing Skill Abuse Fix

### DIFF
--- a/code/modules/roguetown/roguecrafting/structure.dm
+++ b/code/modules/roguetown/roguecrafting/structure.dm
@@ -162,7 +162,6 @@
 	name = "anvil"
 	result = /obj/machinery/anvil
 	reqs = list(/obj/item/ingot/iron = 1)
-	skillcraft = /datum/skill/craft/blacksmithing
 	verbage_simple = "forge"
 	verbage = "forges"
 	skill_level = 2
@@ -205,7 +204,6 @@
 	verbage_simple = "build"
 	verbage = "builds"
 	craftsound = null
-	skillcraft = /datum/skill/craft/blacksmithing
 	skill_level = 2
 
 /datum/crafting_recipe/roguetown/structure/sharpwheel
@@ -213,7 +211,6 @@
 	result = /obj/structure/fluff/grindwheel
 	reqs = list(/obj/item/ingot/iron = 1,
 				/obj/item/natural/stone = 1)
-	skillcraft = /datum/skill/craft/blacksmithing
 	verbage_simple = "build"
 	verbage = "builds"
 	craftsound = null


### PR DESCRIPTION
## About The Pull Request

It was brought to my attention that sharpening wheels were capable of being made by people with 0 blacksmithing skill, higher than 10 int, and it allowed them to spam sharpening wheels to gain smithing skill from nothing.

This was a method used to invalidate the need for smiths, extremely easily, by utilizing swampweed/spice.

Smith players rejoice, your job won't be replaced by Billy Bob the Steward who decided to sit there smoking swampweed in his bed and making 70 sharpening wheels to rival your years of skill.

This PR removes the Anvil, Heat Treatment Furnace and Sharpening Wheel from the "Blacksmithing" crafting tree, putting it in the crafting skill tree, now making it impossible to use very few resources to get Master Blacksmithing in record speedrunning time.

## Why It's Good For The Game

It's honestly just an exploit people use to powergame.
There's no reason this should exist as it currently does.
Thanks for coming to my TEDtalk.