### PR TITLE
Retires Henchman, Longshoreman, and Harbormaster

### DIFF
--- a/code/modules/jobs/job_types/roguetown/mercenaries/merch_merc.dm
+++ b/code/modules/jobs/job_types/roguetown/mercenaries/merch_merc.dm
@@ -1,4 +1,4 @@
-/datum/job/roguetown/grabber
+/* /datum/job/roguetown/grabber
 	title = "Henchman"
 	flag = GRABBER
 	department_flag = MERCENARIES
@@ -136,3 +136,4 @@
 		H.change_stat("speed", 1)
 		H.change_stat("constitution", 1)
 		H.change_stat("intelligence", -4)//On par with a beggar.
+ */

--- a/code/modules/jobs/job_types/roguetown/yeomen/harbormaster.dm
+++ b/code/modules/jobs/job_types/roguetown/yeomen/harbormaster.dm
@@ -1,4 +1,4 @@
-/datum/job/roguetown/harbormaster
+/* /datum/job/roguetown/harbormaster
 	title = "Harbormaster"
 	flag = HARBORMASTER
 	department_flag = GARRISON
@@ -61,3 +61,4 @@
 		H.change_stat("speed", 1)
 		H.change_stat("fortune", 2)
 	ADD_TRAIT(H, TRAIT_MEDIUMARMOR, TRAIT_GENERIC)
+ */

--- a/code/modules/jobs/job_types/roguetown/yeomen/longshoreman.dm
+++ b/code/modules/jobs/job_types/roguetown/yeomen/longshoreman.dm
@@ -1,4 +1,4 @@
-/datum/job/roguetown/longshoreman
+/* /datum/job/roguetown/longshoreman
 	title = "Longshoreman"
 	flag = LONGSHOREMAN
 	department_flag = GARRISON
@@ -58,3 +58,4 @@
 		H.change_stat("speed", 1)
 		H.change_stat("fortune", 1)
 	ADD_TRAIT(H, TRAIT_MEDIUMARMOR, TRAIT_GENERIC)
+ */


### PR DESCRIPTION
## About The Pull Request

Removes these three useless roles. Henchman will likely be brought back down the line.

## Why It's Good For The Game

These roles served no purpose, and were left behind by an old map.
