### PR TITLE
Goblin Shaman INT Fix

### DIFF
--- a/code/modules/jobs/job_types/roguetown/goblin/goblinshaman.dm
+++ b/code/modules/jobs/job_types/roguetown/goblin/goblinshaman.dm
@@ -49,7 +49,7 @@
 		H.mind.adjust_skillrank(/datum/skill/misc/reading, 3, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/magic/holy, 2, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/magic/arcane, 3, TRUE)
-		H.change_stat("intelligence", 4)
+		H.change_stat("intelligence", 6)
 		H.change_stat("fortune", 2)
 
 	var/datum/devotion/C = new /datum/devotion(H, H.patron)


### PR DESCRIPTION
Goblin Shamans were literally too stupid to read their own spellbook.
